### PR TITLE
FIX: Add PI_2 to fix console errors

### DIFF
--- a/src/avatar/mouseLook.js
+++ b/src/avatar/mouseLook.js
@@ -1,5 +1,7 @@
 var objectTracker = require('../support/objectTracker');
 
+PI_2 = Math.PI / 2;
+
 /**
  * AvatarPlugin for a mouse-look based HMD
  */


### PR DESCRIPTION
Error logged was `mouseLook.js:40 Uncaught ReferenceError: PI_2 is not defined`
